### PR TITLE
Moved `cleanData = data` after identification of flat channels

### DIFF
--- a/clean_data_with_zapline_plus.m
+++ b/clean_data_with_zapline_plus.m
@@ -275,7 +275,6 @@ zaplineConfig.prominenceQuantile = prominenceQuantile;
 % initialize results in case no noise frequenc is found
 [pxx_clean_log resSigmaFinal resProportionRemoved resProportionRemovedNoise resProportionRemovedBelowNoise resProportionBelowLower...
     resProportionAboveUpper resRatioNoiseRaw resRatioNoiseClean resNremoveFinal resScores resNoisePeaks resFoundNoise] = deal([]);
-cleanData = data;
 
 %% Clean each frequency one after another
 
@@ -289,6 +288,8 @@ if ~isempty(flat_channels_idx)
     
     data(:,flat_channels_idx) = [];
 end
+
+cleanData = data;
 
 disp('Computing initial spectrum...')
 % compute spectrum with frequency resolution of winSizeCompleteSpectrum


### PR DESCRIPTION
On the rare occasion that zapline-plus does not identify a line noise and that the EEG dataset contains channels with zeros, zapline-plus adds additional rows (i.e., channels) back into the EEG dataset. Moving `cleanData =data` after the if statement on identifying the channels with zeros appears to help prevent this issue.