### PR TITLE
Bugfix: Search noise frequency candidate in 2D

### DIFF
--- a/clean_data_with_zapline_plus.m
+++ b/clean_data_with_zapline_plus.m
@@ -310,7 +310,28 @@ if strcmp(noisefreqs,'line')
     % relative 50 Hz power
     idx = (f>49.9 & f< 50.1) | (f >59.9 & f<60.1);
     
-    noisefreqs_candidate = f(find(pxx_raw_log==max(pxx_raw_log(idx))));
+    % BF_noise_frequency_candidate_search (Suddha Sourav):
+    % Index in 2D, take all channels (i.e. columns) into account by
+    % getting a chunk of the spectra over all electrodes at the fre-
+    % quencies of interest.
+    spectraChunk_allChans = pxx_raw_log(idx,:);
+    
+    % Get the global maximum across all channels, calculated on the 
+    % flattened spectral data chunk.
+    [maxVal, n] = max(spectraChunk_allChans(:));
+    
+    % Find out which row and column (frequency index in the spectral data
+    % chunk, and channel number) the max value was in
+    [fIdx_max, chanIdx_max] = ind2sub(size(spectraChunk_allChans),n);
+    
+    % Find out the frequency: first, relate the spectral data chunk's
+    % indices to the actual frequency indices, then index based on this
+    % vector
+    f_spectraChunk_allChans = f(find(idx));
+    noisefreqs_candidate = f_spectraChunk_allChans(fIdx_max);
+    
+    % P.S. for multiple maximum values, the method anove will always return
+    % the first maximum value, thus one less potential bug
     
     fprintf('"noisefreqs" parameter was set to ''line'', found line noise candidate at %g Hz!\n',noisefreqs_candidate);
     


### PR DESCRIPTION
Previously, the noise frequency candidates were found using the following code:

```matlab
 noisefreqs_candidate = f(find(pxx_raw_log==max(pxx_raw_log(idx))));
```

 This has at least two problems.

**First problem:** Only the first electrode is used for the maximum noise estimation. Explanation:
    The dimension of `pxx_raw_log` is `n_Frequencies_Of_Interest` x `n_Channels`;
    The dimension of idx is `n_Frequencies_of_Interest` x `1`;
    The dimension of f is `n_Frequencies_of_Interest` x `1`
Thus, `pxx_raw_log(idx)` indexes only the first electrode's frequencies of interest,  and `max(pxx_raw_log(idx))` returns the maximum of the first electrode's power spectrum. While for most cases this is a minor artefact and not an extremely serious one, it is nonetheless possible to think of a scenario where the first electrode is not substantially affected by noise, but some other electrodes are. It seems reasonable that the maximum power over all electrodes should be used to calculate the candidate frequency.

**Second problem:** It is possible that multiple maxima exist in the data. If the maxima estimate (based on the first electrode) are located in multiple electrodes, this leads to a syntax error. Example code:
```matlab
f = [47 48 49 50 51 52 53]
idx = 1:7;
pxx_raw_log = [1 2 1 2 1 2 1; 2 5 6 7 6 5 2]'
f(find(pxx_raw_log == max(pxx_raw_log(idx))))
```

We had this error popping up in some datasets, and based on the investigation stumled on this issue. Thanks a lot for the great automated tool, and for making it open source, as well as making it easy to contribute to the project!